### PR TITLE
Added a global option to disable debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Next, install this extension. Inside Nova, select "Extension Library…" from th
 
 ## Configuration
 
-This extension doesn't have any configuration options itself, but you might be interested in creating a ".luacheckrc" configuration file for your projects. The file itself should be written in Lua. Of particular interest is the `std` value which can be set to specify one or more standards which, for example, can stop globals defined by certain frameworks from being flagged by Luacheck. For example, for the LÖVE game framework, use `std="luajit+love"` to stop Luacheck from throwing warnings about accessing the `love` global from your code. See the "[Configuration file](https://luacheck.readthedocs.io/en/stable/config.html)" and "[Command line options](https://luacheck.readthedocs.io/en/stable/cli.html#command-line-options)" sections of [Luacheck's documentation](https://luacheck.readthedocs.io/en/stable/index.html) for more information.
+This extension doesn't have many configuration options itself, but you might be interested in creating a ".luacheckrc" configuration file for your projects. The file itself should be written in Lua. Of particular interest is the `std` value which can be set to specify one or more standards which, for example, can stop globals defined by certain frameworks from being flagged by Luacheck. For example, for the LÖVE game framework, use `std="luajit+love"` to stop Luacheck from throwing warnings about accessing the `love` global from your code. See the "[Configuration file](https://luacheck.readthedocs.io/en/stable/config.html)" and "[Command line options](https://luacheck.readthedocs.io/en/stable/cli.html#command-line-options)" sections of [Luacheck's documentation](https://luacheck.readthedocs.io/en/stable/index.html) for more information.
+
+You can turn off logging of debug messages to the extension console in the extension's preferences in Nova.
 
 ## Troubleshooting
 

--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -21,13 +21,18 @@ class IssuesProvider {
     }
 
     provideIssues(editor) {
-        console.log("in provideIssues");
+        let disableDebugLog = nova.config.get("pro.albright.luacheck.disable-debug-log");
+        if (disableDebugLog == false) {
+            console.log("in provideIssues");
+        }
 
         // provideIssues() seems to sometimes be called before a document is
         // ready to read. Bail out early if so.
         const docLen = editor.document.length;
         if (docLen === 0) {
-            console.log("Bailing out early as document length is 0");
+            if (disableDebugLog == false) {
+                console.log("Bailing out early as document length is 0");
+            }
             return [];
         }
 
@@ -74,7 +79,10 @@ class IssuesProvider {
                 if (line === "") {
                     return;
                 }
-                console.log("in onStdout with line: '" + line + "'");
+
+                if (disableDebugLog == false) {
+                    console.log("in onStdout with line: '" + line + "'");
+                }
 
                 const matches = line.match(lineMatchPattern);
                 if (matches === null) {
@@ -132,7 +140,11 @@ class IssuesProvider {
                 // Get text
                 const fullRange = new Range(0, docLen);
                 const text = editor.document.getTextInRange(fullRange);
-                console.log("in writer.ready callback; doc length: " + text.length);
+
+                if (disableDebugLog == false) {
+                    console.log("in writer.ready callback; doc length: " + text.length);
+                }
+
                 writer.write(text);
                 writer.close();
             });

--- a/extension.json
+++ b/extension.json
@@ -20,5 +20,21 @@
 
     "bugs": "https://github.com/GarrettAlbright/Luacheck.novaextension/issues",
     "homepage": "https://github.com/GarrettAlbright/Luacheck.novaextension",
-    "repository": "https://github.com/GarrettAlbright/Luacheck.novaextension"
+    "repository": "https://github.com/GarrettAlbright/Luacheck.novaextension",
+
+    "config": [
+    {
+        "key": "pro.albright.luacheck.general.section",
+        "title": "General",
+        "type": "section",
+        "children": [
+          {
+            "key": "pro.albright.luacheck.disable-debug-log",
+            "title": "Disable debug log.",
+            "description": "Disable logging of any debuggint info to the extension console.",
+            "type": "boolean",
+            "default": false
+        }]
+      }
+    ],
 }


### PR DESCRIPTION
I still think this is useful, especially when you're debugging other extensions and don't want to be swamped in messages. This defaults to false now thought so that default behavior is unchanged.